### PR TITLE
Add SketchwareProjects.optimizeIds()

### DIFF
--- a/src/main/kotlin/io/sketchware/SketchwareProjects.kt
+++ b/src/main/kotlin/io/sketchware/SketchwareProjects.kt
@@ -89,7 +89,7 @@ class SketchwareProjects(private val sketchwareFolder: File) {
             }
 
             // Increment the indexProject variable
-            indexProject.inc()
+            indexProject++
         }
     }
 

--- a/src/main/kotlin/io/sketchware/SketchwareProjects.kt
+++ b/src/main/kotlin/io/sketchware/SketchwareProjects.kt
@@ -39,4 +39,34 @@ class SketchwareProjects(private val sketchwareFolder: File) {
         return startId
     }
 
+    /* Sketchware (and this library, ironically) gets a free ID by adding one to the highest
+     * folder, making some ID's empty / wasted IDs if a project is deleted under the highest ID.
+     *
+     * Example scenario:
+     * 601, 602, (603 deleted), (604 deleted), 605
+     * Sketchware will create a project on 606, wasting 603, and 604
+     *
+     * This function will move some projects with higher IDs to the empty wasted IDs
+     *
+     * Example scenario:
+     * 601, 602, (603 deleted), (604 deleted), 605
+     *
+     * After calling this function:
+     * 601, 602, 603 (previously 605)
+     *
+     * This function might break some implementations that depends on the project ID, will add a
+     * safer alternative soon
+     *
+     *  - Iyxan23
+     */
+    fun optimizeIds() {
+        var indexProject = 601  // This variable is going to be the anchor
+        var currentID = 601     // This variable is going to be the pointer that points to the current project id in this loop
+        File(File(sketchwareFolder, "mysc"), "list").listFiles().forEach {
+            currentID = it.name
+
+            // TODO: IMPLEMENT THIS
+        }
+    }
+
 }

--- a/src/main/kotlin/io/sketchware/SketchwareProjects.kt
+++ b/src/main/kotlin/io/sketchware/SketchwareProjects.kt
@@ -59,13 +59,37 @@ class SketchwareProjects(private val sketchwareFolder: File) {
      *
      *  - Iyxan23
      */
-    fun optimizeIds() {
+    suspend fun optimizeIds() {
         var indexProject = 601  // This variable is going to be the anchor
-        var currentID = 601     // This variable is going to be the pointer that points to the current project id in this loop
-        File(File(sketchwareFolder, "mysc"), "list").listFiles().forEach {
-            currentID = it.name
+        var currentID: Int      // This variable is going to be the pointer that points to the current project id in this loop
 
-            // TODO: IMPLEMENT THIS
+        val sketchwareFolderPath = sketchwareFolder.absolutePath
+
+        File("$sketchwareFolderPath/mysc/list").listFiles()?.forEach {
+            currentID = it.name.toInt()
+
+            // Check if project at indexProject exists
+            if (!File("$sketchwareFolderPath/mysc/list/$indexProject").exists()) {
+                // Change the project ID (sc_id) on mysc/list/{ID}/project
+                val project = SketchwareProject(ProjectFilesLocations.defaultSketchwareProject(sketchwareFolder, currentID))
+
+                // Change the project id
+                project.editConfig {
+                    this.projectId = indexProject.toString()
+                }
+
+                // Move from it's ID into the empty wasted ID
+                File("$sketchwareFolderPath/mysc/list/$currentID").renameTo(File("$sketchwareFolder/mysc/list/$indexProject"))
+                File("$sketchwareFolderPath/data/$currentID").renameTo(File("$sketchwareFolder/data/$indexProject"))
+                File("$sketchwareFolderPath/bak/$currentID").renameTo(File("$sketchwareFolder/bak/$indexProject"))
+                File("$sketchwareFolderPath/resources/fonts/$currentID").renameTo(File("$sketchwareFolder/resources/fonts/$indexProject"))
+                File("$sketchwareFolderPath/resources/images/$currentID").renameTo(File("$sketchwareFolder/resources/images/$indexProject"))
+                File("$sketchwareFolderPath/resources/sounds/$currentID").renameTo(File("$sketchwareFolder/resources/sounds/$indexProject"))
+                File("$sketchwareFolderPath/resources/icons/$currentID").renameTo(File("$sketchwareFolder/resources/icons/$indexProject"))
+            }
+
+            // Increment the indexProject variable
+            indexProject.inc()
         }
     }
 

--- a/src/main/kotlin/io/sketchware/SketchwareProjects.kt
+++ b/src/main/kotlin/io/sketchware/SketchwareProjects.kt
@@ -84,13 +84,13 @@ class SketchwareProjects(private val sketchwareFolder: File) {
                 }
 
                 // Move from it's ID into the empty wasted ID
-                File("$sketchwareFolderPath/mysc/list/$currentID").renameTo(File("$sketchwareFolder/mysc/list/$indexProject"))
-                File("$sketchwareFolderPath/data/$currentID").renameTo(File("$sketchwareFolder/data/$indexProject"))
-                File("$sketchwareFolderPath/bak/$currentID").renameTo(File("$sketchwareFolder/bak/$indexProject"))
-                File("$sketchwareFolderPath/resources/fonts/$currentID").renameTo(File("$sketchwareFolder/resources/fonts/$indexProject"))
-                File("$sketchwareFolderPath/resources/images/$currentID").renameTo(File("$sketchwareFolder/resources/images/$indexProject"))
-                File("$sketchwareFolderPath/resources/sounds/$currentID").renameTo(File("$sketchwareFolder/resources/sounds/$indexProject"))
-                File("$sketchwareFolderPath/resources/icons/$currentID").renameTo(File("$sketchwareFolder/resources/icons/$indexProject"))
+                File("$sketchwareFolderPath/mysc/list/$currentID").renameTo(File("$sketchwareFolderPath/mysc/list/$indexProject"))
+                File("$sketchwareFolderPath/data/$currentID").renameTo(File("$sketchwareFolderPath/data/$indexProject"))
+                File("$sketchwareFolderPath/bak/$currentID").renameTo(File("$sketchwareFolderPath/bak/$indexProject"))
+                File("$sketchwareFolderPath/resources/fonts/$currentID").renameTo(File("$sketchwareFolderPath/resources/fonts/$indexProject"))
+                File("$sketchwareFolderPath/resources/images/$currentID").renameTo(File("$sketchwareFolderPath/resources/images/$indexProject"))
+                File("$sketchwareFolderPath/resources/sounds/$currentID").renameTo(File("$sketchwareFolderPath/resources/sounds/$indexProject"))
+                File("$sketchwareFolderPath/resources/icons/$currentID").renameTo(File("$sketchwareFolderPath/resources/icons/$indexProject"))
             }
 
             // Increment the indexProject variable

--- a/src/main/kotlin/io/sketchware/SketchwareProjects.kt
+++ b/src/main/kotlin/io/sketchware/SketchwareProjects.kt
@@ -43,19 +43,21 @@ class SketchwareProjects(private val sketchwareFolder: File) {
      * folder, making some ID's empty / wasted IDs if a project is deleted under the highest ID.
      *
      * Example scenario:
-     * 601, 602, (603 deleted), (604 deleted), 605
+     * 601, 602, (603 is deleted), (604 is deleted), 605
      * Sketchware will create a project on 606, wasting 603, and 604
      *
-     * This function will move some projects with higher IDs to the empty wasted IDs
+     * This function will move some projects with higher IDs to the lower empty IDs
      *
      * Example scenario:
-     * 601, 602, (603 deleted), (604 deleted), 605
+     * 601, 602, (603 is deleted), (604 is deleted), 605
      *
      * After calling this function:
-     * 601, 602, 603 (previously 605)
+     * 601, 602, 603 (was previously 605)
      *
      * This function might break some implementations that depends on the project ID, will add a
      * safer alternative soon
+     *
+     * Oh yeah, I'm new to kotlin, so feel free to modify the code if you don't like it
      *
      *  - Iyxan23
      */
@@ -66,10 +68,13 @@ class SketchwareProjects(private val sketchwareFolder: File) {
         val sketchwareFolderPath = sketchwareFolder.absolutePath
 
         File("$sketchwareFolderPath/mysc/list").listFiles()?.forEach {
+
+            // Set the current ID
             currentID = it.name.toInt()
 
             // Check if project at indexProject exists
             if (!File("$sketchwareFolderPath/mysc/list/$indexProject").exists()) {
+
                 // Change the project ID (sc_id) on mysc/list/{ID}/project
                 val project = SketchwareProject(ProjectFilesLocations.defaultSketchwareProject(sketchwareFolder, currentID))
 
@@ -92,5 +97,4 @@ class SketchwareProjects(private val sketchwareFolder: File) {
             indexProject++
         }
     }
-
 }


### PR DESCRIPTION
Sketchware (and this library, ironically) gets a free ID by adding one to the highest ID / folder, making some IDs to be empty / wasted if a project is deleted under the highest ID. 

This function will move some projects with higher IDs to the lower empty IDs, optimizing the ID usage.

I'd say this is a great addition for a Project Manager.

**Also note that this function hasn't been tested yet, don't push this into the stable release until it's tested and / or patched first.**

(Read the code for more explanations)